### PR TITLE
Allow apps to read auxiliary camera properties

### DIFF
--- a/common/private/appdomain.te
+++ b/common/private/appdomain.te
@@ -1,0 +1,1 @@
+get_prop(appdomain, vendor_persist_camera_prop)


### PR DESCRIPTION
Change-Id: Ib9a4e31ff331678c230b105a39c5d3eafa9ef2f2